### PR TITLE
Adapt to get_future interface change

### DIFF
--- a/include/hpx/kokkos/future.hpp
+++ b/include/hpx/kokkos/future.hpp
@@ -36,7 +36,7 @@ template <typename ExecutionSpace> struct get_future {
 template <> struct get_future<Kokkos::Cuda> {
   template <typename E> static hpx::shared_future<void> call(E &&inst) {
     HPX_KOKKOS_DETAIL_LOG("getting future from stream %p", inst.cuda_stream());
-    return hpx::compute::cuda::get_future(inst.cuda_stream());
+    return hpx::cuda::detail::get_future_with_callback(inst.cuda_stream());
   }
 };
 #endif


### PR DESCRIPTION
This PR fixes the get_future call to work with the latest HPX master.